### PR TITLE
Fix IDA16 dataset loading

### DIFF
--- a/phmd/metadata/IDA16.json
+++ b/phmd/metadata/IDA16.json
@@ -202,6 +202,7 @@
             "description": "Historial counts. Missing values replace by -1"
         }
     },
+    "filters": {},
     "system": {},
     "resources": {
         "1. storage": {


### PR DESCRIPTION
Missing "filters" key in IDA16 metadata causes loading failure

When attempting to load the IDA16: Air pressure system failures in Scania trucks dataset, the loading process fails because the metadata JSON does not contain the "filters" key.

Steps to reproduce:

Try to load the IDA16 dataset with the current metadata.

Observe that the loader raises an error due to the missing "filters" field.

Proposed fix:
Add an empty "filters" field to the IDA16 metadata entry: "filters": {}

This resolves the loading issue and allows the dataset to be processed normally.
